### PR TITLE
Fix: calculate GD column if missing

### DIFF
--- a/rank/season_dashboard.Rmd
+++ b/rank/season_dashboard.Rmd
@@ -23,10 +23,12 @@ full_url <- paste0(base_url, csv_file)
 
 df <- read.csv(full_url)
 
+
 # GD (Goal Difference)
 if (!"GD" %in% names(df) & all(c("GF", "GA") %in% names(df))) {
   df <- df %>% mutate(GD = GF - GA)
 }
+
 
 str(df)
 ```


### PR DESCRIPTION
## Changes

### Fix: Add GD calculation to prevent error

### Description

All datasets do not include the `GD` (Goal Difference) column, which caused the dashboard to fail.

(Crawling with the database in mind and removing GD)

This PR adds a conditional check in the setup chunk:

```r
if (!"GD" %in% names(df)) {
  df <- df %>% mutate(GD = GF - GA)
}
```

https://sw1kwon.github.io/assets/html/final_report.html

Fixes #1

## Checklist
- [x] Code runs without error
- [x] Related documentation updated
- [x] Related issue linked
